### PR TITLE
[BRAN-57] Export Icons From Phosphor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,8 +63,7 @@
                 "@mui/styled-engine-sc": "^5.12.0",
                 "@phosphor-icons/react": "^2.0.14",
                 "react": "^18.2.0",
-                "react-dom": "^18.2.0",
-                "styled-components": "^5.3.11"
+                "react-dom": "^18.2.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
             "name": "@latinum-network/mosaic",
             "version": "1.6.0",
             "license": "ISC",
-            "dependencies": {
-                "@phosphor-icons/react": "^2.0.13"
-            },
             "devDependencies": {
                 "@emotion/react": "^11.11.1",
                 "@emotion/styled": "^11.11.0",
@@ -64,6 +61,7 @@
                 "@fontsource/nunito-sans": "^5.0.8",
                 "@mui/material": "^5.12.3",
                 "@mui/styled-engine-sc": "^5.12.0",
+                "@phosphor-icons/react": "^2.0.14",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "styled-components": "^5.3.11"
@@ -3503,9 +3501,10 @@
             }
         },
         "node_modules/@phosphor-icons/react": {
-            "version": "2.0.13",
-            "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.0.13.tgz",
-            "integrity": "sha512-lRjFfCv4pU8vDnPgZ8/QFzYmAJS08Vx+J2/+Ldh217pXaxvaayBZMC/3EinuMwmMylc97+XYCMPdH+y10I+f0g==",
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.0.14.tgz",
+            "integrity": "sha512-VaZ7/JEQ7dW+Up23l7t6lqJ3dPJupM03916Pat+ZOLX1vex9OeX9t8RZLJWt0oVrdc/GcrAyRD5FESDeP+M4tQ==",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -15707,9 +15706,10 @@
             }
         },
         "@phosphor-icons/react": {
-            "version": "2.0.13",
-            "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.0.13.tgz",
-            "integrity": "sha512-lRjFfCv4pU8vDnPgZ8/QFzYmAJS08Vx+J2/+Ldh217pXaxvaayBZMC/3EinuMwmMylc97+XYCMPdH+y10I+f0g==",
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.0.14.tgz",
+            "integrity": "sha512-VaZ7/JEQ7dW+Up23l7t6lqJ3dPJupM03916Pat+ZOLX1vex9OeX9t8RZLJWt0oVrdc/GcrAyRD5FESDeP+M4tQ==",
+            "peer": true,
             "requires": {}
         },
         "@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
         "@mui/styled-engine-sc": "^5.12.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "styled-components": "^5.3.11",
         "@phosphor-icons/react": "^2.0.14"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
         "@mui/styled-engine-sc": "^5.12.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "styled-components": "^5.3.11"
+        "styled-components": "^5.3.11",
+        "@phosphor-icons/react": "^2.0.14"
     },
     "devDependencies": {
         "@emotion/react": "^11.11.1",
@@ -115,8 +116,5 @@
             "last 1 firefox version",
             "last 1 safari version"
         ]
-    },
-    "dependencies": {
-        "@phosphor-icons/react": "^2.0.13"
     }
 }

--- a/src/components/atoms/Icons/Icons.mdx
+++ b/src/components/atoms/Icons/Icons.mdx
@@ -4,7 +4,9 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Phosphor Icons
 
-In this component library, we exclusively use Phosphor icons. You can use the Phosphor icon library through this component library.
+In this component library, we exclusively use Phosphor for icons. You can use the Phosphor icon library through this component library.
+
+You can check out their [icons](https://phosphoricons.com/) here.
 
 ## How to Use
 

--- a/src/components/atoms/Icons/Icons.mdx
+++ b/src/components/atoms/Icons/Icons.mdx
@@ -1,0 +1,17 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Atoms/Icons" />
+
+# Phosphor Icons
+
+In this component library, we exclusively use Phosphor icons. You can use the Phosphor icon library through this component library.
+
+## How to Use
+
+Import the `Icon` namespace and use its exported icons like properties:
+
+```jsx
+import { Icon } from '@latinum-network/mosaic';
+
+<Icon.House />
+```

--- a/src/components/atoms/Icons/Icons.mdx
+++ b/src/components/atoms/Icons/Icons.mdx
@@ -13,5 +13,5 @@ Import the `Icon` namespace and use its exported icons like properties:
 ```jsx
 import { Icon } from '@latinum-network/mosaic';
 
-<Icon.House />
+<Icon.House />;
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import type {
 export * from './colors';
 export * from './typings';
 export * from './theme';
+export * as Icon from '@phosphor-icons/react';
 
 export * from '@mui/material';
 


### PR DESCRIPTION
## Purpose/Description:

- Export icons from phosphor through `mosaic`

## Jira Link: 

[BRAN-57](https://collagegroup.atlassian.net/browse/BRAN-57)



[BRAN-57]: https://collagegroup.atlassian.net/browse/BRAN-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ