### PR TITLE
[BRAN-42] Nunito Sans SVG Text

### DIFF
--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -135,6 +135,9 @@ const themeOptions: ThemeOptions = {
         body: {
           fontFamily: "'Nunito Sans', sans-serif",
         },
+        'svg text': {
+          fontFamily: "'Nunito Sans', sans-serif",
+        },
       },
     },
   },


### PR DESCRIPTION
## Purpose/Description:

- Force SVG text to also be in our desired font

### Screenshots:

![image](https://github.com/LatinumNetwork/mosaic/assets/1088165/8a15ad15-fc25-4821-9a06-6d4d71c312c7)
![image](https://github.com/LatinumNetwork/mosaic/assets/1088165/6f40e76f-3798-4943-b15f-c5d9656d61fb)

## Jira Link:

[BRAN-42](https://collagegroup.atlassian.net/browse/BRAN-405)




[BRAN-42]: https://collagegroup.atlassian.net/browse/BRAN-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ