### PR TITLE
[BRAN-410] Move streamline icon component from dashboard to mosaic

### DIFF
--- a/src/components/atoms/StreamlineIcon/StreamlineIcon.stories.tsx
+++ b/src/components/atoms/StreamlineIcon/StreamlineIcon.stories.tsx
@@ -1,0 +1,36 @@
+import { StoryFn } from '@storybook/react';
+import { StreamlineIcons } from 'src/typings';
+
+import { StreamlineIcon, StreamlineIconProps } from './StreamlineIcon';
+
+const argTypes = {
+  name: {
+    control: { type: 'radio' },
+    options: ['lightbulb', 'performance_increase', 'like', 'shopping_basket'],
+  },
+};
+
+export default {
+  title: 'Atoms/StreamlineIcon',
+  component: StreamlineIcon,
+  argTypes,
+  parameters: {
+    controls: { include: Object.keys(argTypes) },
+  },
+};
+
+const Template: StoryFn<typeof StreamlineIcon> = ({
+  ...args
+}: StreamlineIconProps): React.JSX.Element => <StreamlineIcon {...args} />;
+
+export const Lightbulb = Template.bind({});
+Lightbulb.args = { name: StreamlineIcons.Lightbulb };
+
+export const PerformanceIncrease = Template.bind({});
+PerformanceIncrease.args = { name: StreamlineIcons.PerformanceIncrease };
+
+export const Like = Template.bind({});
+Like.args = { name: StreamlineIcons.Like };
+
+export const ShoppingBasket = Template.bind({});
+ShoppingBasket.args = { name: StreamlineIcons.ShoppingBasket };

--- a/src/components/atoms/StreamlineIcon/StreamlineIcon.tsx
+++ b/src/components/atoms/StreamlineIcon/StreamlineIcon.tsx
@@ -1,0 +1,244 @@
+import { StreamlineIcons } from 'src/typings';
+
+export type StreamlineIconProps = {
+  name: StreamlineIcons;
+};
+
+export const StreamlineIcon = ({ name }: StreamlineIconProps) => {
+  switch (name) {
+    case StreamlineIcons.Lightbulb:
+      return (
+        <svg
+          width="40"
+          height="40"
+          viewBox="0 0 40 40"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          data-testid="lightbulb-icon"
+        >
+          <g stroke="currentColor">
+            <path
+              d="M20 36.6665V39.1665"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M25 28.8081V33.3331C25 35.7098 23 36.6664 20 36.6664C17 36.6664 15 35.7098 15 33.3331V28.8081"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M20.0001 28.6618V21.6668L16.6667 18.3335"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M24.1666 29.1668C26.1628 28.3755 27.8702 26.9944 29.0613 25.2077C30.2524 23.4211 30.8706 21.3138 30.8333 19.1668C30.7824 16.3096 29.6247 13.5836 27.6039 11.5628C25.5832 9.54213 22.8572 8.38442 20 8.3335C17.1427 8.38442 14.4167 9.54213 12.396 11.5628C10.3753 13.5836 9.21755 16.3096 9.16663 19.1668C9.12936 21.3138 9.74749 23.4211 10.9386 25.2077C12.1297 26.9944 13.8372 28.3755 15.8333 29.1668H24.1666Z"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M15 32.5H25"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M20 0.833496V4.16683"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M1.66675 17.5H5.48508"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M5.83325 5L9.16659 8.33333"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M38.3332 17.5H34.5149"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M34.1666 5L30.8333 8.33333"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M20 21.6668L23.3333 18.3335"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </g>
+        </svg>
+      );
+    case StreamlineIcons.PerformanceIncrease:
+      return (
+        <svg
+          width="40"
+          height="40"
+          viewBox="0 0 40 40"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          data-testid="performance_increase-icon"
+        >
+          <g stroke="currentColor">
+            <path
+              d="M0.840088 38.75H39.1734"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M7.5 38.75V34.5833C7.5 34.3623 7.4122 34.1504 7.25592 33.9941C7.09964 33.8378 6.88768 33.75 6.66667 33.75H3.33333C3.11232 33.75 2.90036 33.8378 2.74408 33.9941C2.5878 34.1504 2.5 34.3623 2.5 34.5833V38.75"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M17.5 38.7502V27.9168C17.5 27.6958 17.4122 27.4839 17.2559 27.3276C17.0996 27.1713 16.8877 27.0835 16.6667 27.0835H13.3333C13.1123 27.0835 12.9004 27.1713 12.7441 27.3276C12.5878 27.4839 12.5 27.6958 12.5 27.9168V38.7502"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M27.5 38.7498V21.2498C27.5 21.0288 27.4122 20.8169 27.2559 20.6606C27.0996 20.5043 26.8877 20.4165 26.6667 20.4165H23.3333C23.1123 20.4165 22.9004 20.5043 22.7441 20.6606C22.5878 20.8169 22.5 21.0288 22.5 21.2498V38.7498"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M37.5 38.75V14.5833C37.5 14.4739 37.4784 14.3655 37.4366 14.2644C37.3947 14.1633 37.3333 14.0715 37.2559 13.9941C37.1785 13.9167 37.0867 13.8553 36.9856 13.8134C36.8845 13.7716 36.7761 13.75 36.6667 13.75H33.3333C33.1123 13.75 32.9004 13.8378 32.7441 13.9941C32.5878 14.1504 32.5 14.3623 32.5 14.5833V38.75"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M5.00659 22.0835L35.0066 2.0835"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M34.1734 8.75L35.0068 2.08333L28.3401 1.25"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </g>
+        </svg>
+      );
+    case StreamlineIcons.Like:
+      return (
+        <svg
+          width="40"
+          height="40"
+          viewBox="0 0 40 40"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          data-testid="like-icon"
+        >
+          <g stroke="currentColor">
+            <path
+              d="M33.3334 26.0983C33.9965 26.0983 34.6323 26.3617 35.1012 26.8306C35.57 27.2994 35.8334 27.9353 35.8334 28.5983C35.8334 29.2614 35.57 29.8973 35.1012 30.3661C34.6323 30.8349 33.9965 31.0983 33.3334 31.0983H31.6667C32.3298 31.0983 32.9657 31.3617 33.4345 31.8306C33.9034 32.2994 34.1667 32.9353 34.1667 33.5983C34.1667 34.98 33.0467 35.265 31.6667 35.265H20.8334C16.0817 35.265 15.0001 34.4317 9.16675 33.5983V19.4317C13.2501 19.4317 20.0001 11.9317 20.0001 5.265C20.0001 2.63 23.6484 1.64833 25.0001 6.46333C25.8334 9.43167 23.3334 15.265 23.3334 15.265H36.6667C37.3298 15.265 37.9657 15.5284 38.4345 15.9972C38.9034 16.4661 39.1667 17.102 39.1667 17.765C39.1667 19.1467 38.0467 21.0983 36.6667 21.0983H35.0001C35.6631 21.0983 36.299 21.3617 36.7678 21.8306C37.2367 22.2994 37.5001 22.9353 37.5001 23.5983C37.5001 24.2614 37.2367 24.8973 36.7678 25.3661C36.299 25.8349 35.6631 26.0983 35.0001 26.0983H33.3334Z"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M9.16659 16.9316H0.833252V36.9316H9.16659V16.9316Z"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M5.41667 33.5985C5.30616 33.5985 5.20018 33.5546 5.12204 33.4764C5.0439 33.3983 5 33.2923 5 33.1818C5 33.0713 5.0439 32.9653 5.12204 32.8872C5.20018 32.809 5.30616 32.7651 5.41667 32.7651"
+              strokeWidth="1.66667"
+            />
+            <path
+              d="M5.41675 33.5985C5.52725 33.5985 5.63324 33.5546 5.71138 33.4764C5.78952 33.3983 5.83342 33.2923 5.83342 33.1818C5.83342 33.0713 5.78952 32.9653 5.71138 32.8872C5.63324 32.809 5.52725 32.7651 5.41675 32.7651"
+              strokeWidth="1.66667"
+            />
+          </g>
+        </svg>
+      );
+    case StreamlineIcons.ShoppingBasket:
+      return (
+        <svg
+          width="40"
+          height="40"
+          viewBox="0 0 40 40"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          data-testid="shopping_basket-icon"
+        >
+          <g stroke="currentColor">
+            <path
+              d="M34.435 36.1668C34.3581 36.5436 34.1533 36.8821 33.8553 37.1251C33.5573 37.3681 33.1845 37.5006 32.8 37.5002H7.2C6.8155 37.5006 6.44266 37.3681 6.14468 37.1251C5.8467 36.8821 5.6419 36.5436 5.565 36.1668L2.5 20.8335H37.5L34.435 36.1668Z"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M2.49992 15.8335H37.4999C37.4999 15.8335 39.1666 15.8335 39.1666 17.5002V19.1668C39.1666 19.1668 39.1666 20.8335 37.4999 20.8335H2.49992C2.49992 20.8335 0.833252 20.8335 0.833252 19.1668V17.5002C0.833252 17.5002 0.833252 15.8335 2.49992 15.8335Z"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M5.83325 12.5L15.8333 2.5"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M34.1667 12.5L24.1667 2.5"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M22.5 24.1665V32.4998"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M29.1667 24.1665V32.4998"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M17.5 24.1665V32.4998"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M10.8333 24.1665V32.4998"
+              strokeWidth="1.66667"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </g>
+        </svg>
+      );
+    default:
+      return <p>x</p>;
+  }
+};

--- a/src/components/atoms/StreamlineIcon/index.tsx
+++ b/src/components/atoms/StreamlineIcon/index.tsx
@@ -1,0 +1,2 @@
+export { StreamlineIcon } from './StreamlineIcon';
+export type { StreamlineIconProps } from './StreamlineIcon';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,5 +11,8 @@ export type { BoxProps } from './atoms/Box';
 export { Breadcrumbs } from './atoms/Breadcrumbs';
 export type { BreadcrumbsProps } from './atoms/Breadcrumbs';
 
+export { StreamlineIcon } from './atoms/StreamlineIcon';
+export type { StreamlineIconProps } from './atoms/StreamlineIcon';
+
 export { BaseCard } from './molecules/BaseCard';
 export type { BaseCardProps, CardHeaderProps } from './molecules/BaseCard';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import type {
   Breadcrumbs,
   BreadcrumbsProps,
   ButtonProps,
+  StreamlineIcon,
+  StreamlineIconProps,
   TypographyProps,
 } from './components';
 
@@ -37,4 +39,6 @@ export {
   hexToRgba,
   BaseCard,
   BaseCardProps,
+  StreamlineIcon,
+  StreamlineIconProps,
 };

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -13,3 +13,10 @@ export enum PaletteColors {
   uiYellow = 'uiYellow',
   uiRed = 'uiRed',
 }
+
+export enum StreamlineIcons {
+  Lightbulb = 'lightbulb',
+  PerformanceIncrease = 'performance_increase',
+  Like = 'like',
+  ShoppingBasket = 'shopping_basket',
+}


### PR DESCRIPTION
## Purpose/Description:

Moved StreamlineIcon component from dashboard to mosaic and added a storybook component

## Screenshots

<img width="1582" alt="image" src="https://github.com/LatinumNetwork/mosaic/assets/44757003/2257b2cf-d2da-44f0-8604-13102b3a2060">

## Jira Link:

[BRAN-410](https://collagegroup.atlassian.net/browse/BRAN-410)

## Test Plan:

-   **Test Scenario 1:** Test in Storybook

    -   **Steps:**
        1. In mosaic run `npm run storybook`
        2. Test StreamlineIcon component
    -   **Expected Result:** All four icons should appear as expected.

## Additional Notes

Make a ticket for implementing this in dashboard


[BRAN-410]: https://collagegroup.atlassian.net/browse/BRAN-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ