### PR TITLE
BRAN-820: Fix export of BaseCard

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,7 @@
 import { hexToRgba } from 'src/utils';
 
-import { Box, Button, Typography } from './components';
+import { BaseCard, Box, Button, Typography } from './components';
 import type {
-  BaseCard,
   BaseCardProps,
   BoxProps,
   Breadcrumbs,


### PR DESCRIPTION
## Purpose/Description:

BaseCard was being exported as a type instead of a component. This was an easy fix by just moving where it was being imported in the source index.tsx file.

## Test Plan:

-   **Test Scenario 1:** Make sure it works in dashboard.

    -   **Steps:**
        1. Link mosaic to dashboard using yalc [(documentation on how)](https://collagegroup.atlassian.net/wiki/spaces/SD/pages/92536834/Mosaic+101#Testing-Your-Component)
        2. In dashboard, replace an instance of BaseCard with one imported from mosaic
    -   **Expected Result:** There should be no visible differences.
