### PR TITLE
[BRAN-837] Allow children instead of title in BaseCard

### DIFF
--- a/src/components/molecules/BaseCard/BaseCard.tsx
+++ b/src/components/molecules/BaseCard/BaseCard.tsx
@@ -9,10 +9,11 @@ export type BaseCardProps = {
 };
 
 export type CardHeaderProps = {
-  title: string;
+  title?: string;
   description?: string;
   actions?: ReactNode;
   sx?: SxProps;
+  children?: ReactNode;
 };
 
 export type CardBodyProps = {
@@ -54,17 +55,20 @@ const BodyStyled = styled(Box)(({ theme }) => ({
 }));
 
 const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(
-  ({ title, description, actions, sx, ...rest }, ref) => (
+  ({ title, description, actions, sx, children, ...rest }, ref) => (
     <HeaderStyled ref={ref} sx={sx} {...rest}>
-      <Box>
-        <Typography variant="h1">{title}</Typography>
-        {description && (
-          <Typography variant="b1" color="textSecondary">
-            {description}
-          </Typography>
-        )}
-      </Box>
+      {title && (
+        <Box>
+          <Typography variant="h1">{title}</Typography>
+          {description && (
+            <Typography variant="b1" color="textSecondary">
+              {description}
+            </Typography>
+          )}
+        </Box>
+      )}
       {actions && <Box>{actions}</Box>}
+      {children}
     </HeaderStyled>
   )
 );


### PR DESCRIPTION
## Purpose/Description:

The DataVisualizationCard component in dashboard needed more flexibility with the title and description. I added the ability to pass children to BaseCard.Header and made the title optional.

## Jira Link:

[BRAN-837](https://collagegroup.atlassian.net/browse/BRAN-837)

### Deployment Considerations:

This is needed to complete [BRAN-431](https://collagegroup.atlassian.net/browse/BRAN-431)


[BRAN-837]: https://collagegroup.atlassian.net/browse/BRAN-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRAN-431]: https://collagegroup.atlassian.net/browse/BRAN-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ