### PR TITLE
BRAN-602: Migrate GraphTooltips to Mosaic

### DIFF
--- a/src/components/atoms/GraphTooltips/GraphTooltips.tsx
+++ b/src/components/atoms/GraphTooltips/GraphTooltips.tsx
@@ -1,4 +1,4 @@
-import { Box, BoxProps, SxProps, Theme, styled } from '@latinum-network/mosaic';
+import { Box, BoxProps, SxProps, Theme, styled } from '@mui/material';
 
 import {
   Container,

--- a/src/components/atoms/GraphTooltips/GraphTooltips.tsx
+++ b/src/components/atoms/GraphTooltips/GraphTooltips.tsx
@@ -1,0 +1,135 @@
+import { Box, BoxProps, SxProps, Theme, styled } from '@latinum-network/mosaic';
+
+import {
+  Container,
+  Label,
+  Row,
+  UnitMeasurement,
+  Value,
+} from './components/commonComponents';
+import { getArrowStyles, getTooltipPositionStyles } from './utils';
+
+export type ArrowPosition = 'top' | 'bottom' | 'left' | 'right';
+export type xPosition = 'left' | 'right' | 'center';
+export type yPosition = 'top' | 'bottom' | 'center';
+
+export interface ShowTooltipArgs<T> {
+  tooltipData: T;
+  tooltipLeft?: number;
+  tooltipTop?: number;
+}
+
+export interface TooltipParams<T> {
+  tooltipOpen: boolean;
+  tooltipLeft?: number;
+  tooltipTop?: number;
+  tooltipData?: T;
+  showTooltip: (args: ShowTooltipArgs<T>) => void;
+  hideTooltip: () => void;
+  arrowPosition?: ArrowPosition | undefined;
+  xPosition?: xPosition;
+  yPosition?: yPosition;
+  unitMeasurement?: string;
+}
+
+export type GraphTooltipData = { label?: string; value?: string | number }[];
+
+interface GraphTooltipProps {
+  rows: { label?: string; value?: string | number }[];
+  unitMeasurement?: string;
+  top?: number;
+  left?: number;
+  right?: number;
+  width?: number | 'auto';
+  height?: number | 'auto';
+  className?: string;
+  sx?: SxProps<Theme>;
+  arrowPosition?: ArrowPosition;
+  xPosition?: xPosition;
+  yPosition?: yPosition;
+  open?: boolean;
+}
+
+interface StyledGraphTooltipProps extends BoxProps {
+  arrowPosition: ArrowPosition;
+}
+
+const padding = { top: 6, left: 8 };
+const margin = 0;
+
+const StyledGraphTooltip = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'arrowPosition',
+})<StyledGraphTooltipProps>(({ theme, arrowPosition }) => ({
+  display: 'flex',
+  position: 'absolute',
+  backgroundColor: theme.palette.uiCoolGray[900],
+  color: theme.palette.common.white,
+  borderRadius: '2px',
+  fontSize: '12px',
+  zIndex: 6,
+  textWrap: 'nowrap',
+  '&:after': getArrowStyles(theme, arrowPosition),
+  pointerEvents: 'none',
+}));
+
+export const GraphTooltip = ({
+  className,
+  sx,
+  rows,
+  unitMeasurement,
+  top = 0,
+  left,
+  right,
+  width,
+  height,
+  arrowPosition = 'bottom',
+  xPosition = 'left',
+  yPosition = 'center',
+  open = false,
+}: GraphTooltipProps) => {
+  const positionStyles = getTooltipPositionStyles(
+    xPosition,
+    yPosition,
+    top,
+    left,
+    right,
+    width,
+    height
+  );
+
+  if (!open) return null;
+
+  return (
+    <StyledGraphTooltip
+      sx={{
+        ...positionStyles,
+        padding: `${padding.top}px ${padding.left}px`,
+        margin: `${margin}`,
+        width,
+        height,
+        ...sx,
+      }}
+      arrowPosition={arrowPosition}
+      className={className}
+    >
+      <Container>
+        {rows.map((row) => (
+          <Row
+            key={`tooltip-row-${row.label}-${row.value || 0}`}
+            sx={{ gap: '8px' }}
+          >
+            {row.label && <Label isSingleItem={!row.value}>{row.label}</Label>}
+            {row.value && (
+              <Value>
+                {row.value}
+                {unitMeasurement && (
+                  <UnitMeasurement>{unitMeasurement}</UnitMeasurement>
+                )}
+              </Value>
+            )}
+          </Row>
+        ))}
+      </Container>
+    </StyledGraphTooltip>
+  );
+};

--- a/src/components/atoms/GraphTooltips/components/commonComponents.tsx
+++ b/src/components/atoms/GraphTooltips/components/commonComponents.tsx
@@ -1,0 +1,49 @@
+import {
+  Box,
+  Typography,
+  TypographyProps,
+  styled,
+} from '@latinum-network/mosaic';
+
+export const Container = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px',
+  justifyContent: 'space-between',
+  flex: 1,
+});
+
+export const Row = styled(Box)({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'flex-end',
+  gap: '4px',
+  minWidth: 0,
+  overflow: 'hidden',
+});
+
+export const Label = styled(
+  (props: TypographyProps & { isSingleItem: boolean }) => (
+    <Typography variant="b3" {...props} />
+  ),
+  {
+    shouldForwardProp: (propName) => propName !== 'isSingleItem',
+  }
+)(({ isSingleItem, theme }) => ({
+  // TODO: Replace color with transparency colors in Mosaic
+  color: isSingleItem ? theme.palette.common.white : 'rgba(255, 255, 255, 0.8)',
+  textAlign: 'left',
+}));
+
+export const Value = styled((props: TypographyProps) => (
+  <Typography variant="b2" {...props} />
+))(({ theme }) => ({
+  color: theme.palette.uiWhite[500],
+  minWidth: '30px',
+}));
+
+export const UnitMeasurement = styled((props: TypographyProps) => (
+  <Typography {...props} variant="b3" component="span" />
+))({
+  display: 'inline-block',
+});

--- a/src/components/atoms/GraphTooltips/components/commonComponents.tsx
+++ b/src/components/atoms/GraphTooltips/components/commonComponents.tsx
@@ -1,9 +1,4 @@
-import {
-  Box,
-  Typography,
-  TypographyProps,
-  styled,
-} from '@latinum-network/mosaic';
+import { Box, Typography, TypographyProps, styled } from '@mui/material';
 
 export const Container = styled(Box)({
   display: 'flex',

--- a/src/components/atoms/GraphTooltips/components/commonComponents.tsx
+++ b/src/components/atoms/GraphTooltips/components/commonComponents.tsx
@@ -1,4 +1,5 @@
 import { Box, Typography, TypographyProps, styled } from '@mui/material';
+import { hexToRgba } from 'src/utils';
 
 export const Container = styled(Box)({
   display: 'flex',
@@ -25,8 +26,9 @@ export const Label = styled(
     shouldForwardProp: (propName) => propName !== 'isSingleItem',
   }
 )(({ isSingleItem, theme }) => ({
-  // TODO: Replace color with transparency colors in Mosaic
-  color: isSingleItem ? theme.palette.common.white : 'rgba(255, 255, 255, 0.8)',
+  color: isSingleItem
+    ? theme.palette.common.white
+    : hexToRgba(theme.palette.common.white, 0.8),
   textAlign: 'left',
 }));
 

--- a/src/components/atoms/GraphTooltips/index.ts
+++ b/src/components/atoms/GraphTooltips/index.ts
@@ -1,0 +1,6 @@
+export { GraphTooltip } from './GraphTooltips';
+export type {
+  GraphTooltipData,
+  ShowTooltipArgs,
+  TooltipParams,
+} from './GraphTooltips';

--- a/src/components/atoms/GraphTooltips/utils.ts
+++ b/src/components/atoms/GraphTooltips/utils.ts
@@ -1,4 +1,4 @@
-import { Theme } from '@latinum-network/mosaic';
+import { Theme } from '@mui/material';
 import { CSSProperties } from 'react';
 
 import { ArrowPosition, xPosition, yPosition } from './GraphTooltips';

--- a/src/components/atoms/GraphTooltips/utils.ts
+++ b/src/components/atoms/GraphTooltips/utils.ts
@@ -1,0 +1,119 @@
+import { Theme } from '@latinum-network/mosaic';
+import { CSSProperties } from 'react';
+
+import { ArrowPosition, xPosition, yPosition } from './GraphTooltips';
+
+export const getTooltipPositionStyles = (
+  XPosition: xPosition,
+  YPosition: yPosition,
+  top: number,
+  left?: number,
+  right?: number,
+  width: number | 'auto' = 0,
+  height: number | 'auto' = 0
+): CSSProperties => {
+  let styles: CSSProperties = {};
+
+  if (left) {
+    switch (XPosition) {
+      case 'center':
+        styles = {
+          ...styles,
+          transform: `translateX(-50%)`,
+          left: `${left}px`,
+        };
+        break;
+      case 'right':
+        styles = {
+          ...styles,
+          left:
+            typeof width === 'number' ? `${left - width}px` : `${left - 100}px`,
+        };
+        break;
+      case 'left':
+        styles = {
+          ...styles,
+          left: `${left}px`,
+        };
+        break;
+    }
+  } else if (right) {
+    styles = {
+      ...styles,
+      right: `${right}px`,
+    };
+  }
+
+  switch (YPosition) {
+    case 'center':
+      styles = {
+        ...styles,
+        transform: `${
+          styles.transform ? styles.transform + ' ' : ''
+        }translateY(-50%)`,
+        top: `${top}px`,
+      };
+      break;
+    case 'bottom':
+      styles = {
+        ...styles,
+        top: typeof height === 'number' ? `${top - height}px` : `${top - 48}px`,
+      };
+      break;
+    case 'top':
+      styles = {
+        ...styles,
+        top: `${top}px`,
+      };
+      break;
+  }
+
+  return styles;
+};
+
+export const getArrowStyles = (theme: Theme, position: ArrowPosition) => {
+  const { uiGray } = theme.palette;
+  const common = {
+    content: '""',
+    position: 'absolute',
+    borderWidth: '5px',
+    borderStyle: 'solid',
+  };
+
+  switch (position) {
+    case 'top':
+      return {
+        ...common,
+        bottom: '100%',
+        left: '50%',
+        marginLeft: '-5px',
+        borderColor: `transparent transparent ${uiGray[800]} transparent`,
+      };
+    case 'bottom':
+      return {
+        ...common,
+        top: '100%',
+        left: '50%',
+        marginLeft: '-5px',
+        borderColor: `${uiGray[800]} transparent transparent transparent`,
+      };
+    case 'left':
+      return {
+        ...common,
+        right: '99%',
+        top: '50%',
+        marginTop: '-5px',
+        borderColor: `transparent ${uiGray[800]} transparent transparent`,
+      };
+    case 'right':
+      return {
+        ...common,
+        top: '50%',
+        left: '100%',
+        marginTop: '-5px',
+        borderColor: `transparent transparent transparent ${uiGray[800]}`,
+      };
+    default:
+      return {};
+  }
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,24 +1,32 @@
 // atoms
-export { Typography } from './atoms/Typography';
-export type { TypographyProps } from './atoms/Typography';
-
-export { Button } from './atoms/Button';
-export type { ButtonProps } from './atoms/Button';
-
 export { Box } from './atoms/Box';
 export type { BoxProps } from './atoms/Box';
 
 export { Breadcrumbs } from './atoms/Breadcrumbs';
 export type { BreadcrumbsProps } from './atoms/Breadcrumbs';
 
-export { StreamlineIcon } from './atoms/StreamlineIcon';
-export type { StreamlineIconProps } from './atoms/StreamlineIcon';
+export { Button } from './atoms/Button';
+export type { ButtonProps } from './atoms/Button';
 
-export { BaseCard } from './molecules/BaseCard';
-export type { BaseCardProps, CardHeaderProps } from './molecules/BaseCard';
+export { GraphTooltip } from './atoms/GraphTooltips';
+export type {
+  GraphTooltipData,
+  ShowTooltipArgs,
+  TooltipParams,
+} from './atoms/GraphTooltips';
 
 export { Page } from './atoms/Page';
 export type { PageProps } from './atoms/Page';
 
 export { Row } from './atoms/Row';
 export type { RowProps } from './atoms/Row';
+
+export { StreamlineIcon } from './atoms/StreamlineIcon';
+export type { StreamlineIconProps } from './atoms/StreamlineIcon';
+
+export { Typography } from './atoms/Typography';
+export type { TypographyProps } from './atoms/Typography';
+
+// molecules
+export { BaseCard } from './molecules/BaseCard';
+export type { BaseCardProps, CardHeaderProps } from './molecules/BaseCard';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,21 @@
 import { hexToRgba } from 'src/utils';
 
-import { BaseCard, Box, Button, Typography } from './components';
+import { BaseCard, Box, Button, GraphTooltip, Typography } from './components';
 import type {
   BaseCardProps,
   BoxProps,
   Breadcrumbs,
   BreadcrumbsProps,
   ButtonProps,
+  GraphTooltipData,
   Page,
   PageProps,
   Row,
   RowProps,
+  ShowTooltipArgs,
   StreamlineIcon,
   StreamlineIconProps,
+  TooltipParams,
   TypographyProps,
 } from './components';
 
@@ -31,21 +34,25 @@ export {
 } from '@mui/material/styles';
 
 export {
-  Box,
-  BoxProps,
-  Button,
-  ButtonProps,
-  Typography,
-  TypographyProps,
-  Breadcrumbs,
-  BreadcrumbsProps,
-  hexToRgba,
   BaseCard,
   BaseCardProps,
+  Box,
+  BoxProps,
+  Breadcrumbs,
+  BreadcrumbsProps,
+  Button,
+  ButtonProps,
+  hexToRgba,
+  GraphTooltip,
+  GraphTooltipData,
+  ShowTooltipArgs,
+  TooltipParams,
   Page,
   PageProps,
   Row,
   RowProps,
   StreamlineIcon,
   StreamlineIconProps,
+  Typography,
+  TypographyProps,
 };


### PR DESCRIPTION
## Purpose/Description:

Added the new GraphTooltips component to Mosaic.
Also alphabetized imports and exports in some files.

## Jira Link:

[BRAN-602](https://collagegroup.atlassian.net/browse/BRAN-602)


[BRAN-602]: https://collagegroup.atlassian.net/browse/BRAN-602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ