### PR TITLE
[BRAN-918] Fix error in hexToRgba

### DIFF
--- a/src/utils/hexToRgba.ts
+++ b/src/utils/hexToRgba.ts
@@ -1,7 +1,7 @@
 export default (hex: string, opacity: number): string => {
   hex = hex.replace(/^#/, '');
 
-  if (hex.length !== 6) {
+  if (hex.length !== 6 && hex.length !== 3) {
     throw new Error('Invalid hex color format');
   }
 


### PR DESCRIPTION
## Purpose/Description:

`hexToRgba` was only excepting 6 character hex codes.
`graphTooltips` were sending `theme.palette.common.white` which is `'#FFF'`
I updated to function to allow either 3 or 6 characters so that `common.white` and `common.black` don't break it.

### Screenshots:

The error that was being thrown
<img width="1462" alt="image" src="https://github.com/user-attachments/assets/298b16cf-0f72-4e28-b693-1a5608a477fe">

## Jira Link:

[BRAN-918](https://collagegroup.atlassian.net/browse/BRAN-918)

## Test Plan:

-   **Test Scenario 1:** Test with GraphTooltips.

    -   **Steps:**
        1. Switch to branch BRAN-839 in dashboard and BRAN-918 in mosaic
        2. Connect mosaic and dashboard to yalc - [link to how](https://collagegroup.atlassian.net/wiki/spaces/SD/pages/92536834/Mosaic+101#Testing-Your-Component)
        3. Try hovering on any bar graphs
    -   **Expected Result:** With mosaic running locally, there should be no errors thrown.

-   **Test Scenario 2:** Disconnect mosaic to check error.
    -   **Steps:**
        1. Disconnect dashboard from mosaic
        2. Try hovering on any bar graph
    -   **Expected Result:** Should see the same error as above.

## Additional Notes

### Deployment Considerations:

Needed for [BRAN-839](https://collagegroup.atlassian.net/browse/BRAN-839)

[BRAN-918]: https://collagegroup.atlassian.net/browse/BRAN-918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRAN-839]: https://collagegroup.atlassian.net/browse/BRAN-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ