### PR TITLE
Fixed default right font family in the button

### DIFF
--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -136,6 +136,7 @@ const themeOptions: ThemeOptions = {
     MuiButton: {
       styleOverrides: {
         root: {
+          fontFamily: "'Nunito Sans', 'Merriweather', sans-serif",
           '&:hover': {
             boxShadow: 'none',
           },


### PR DESCRIPTION
## Purpose/Description:

The button component does not pick by default the custom typography rule set in the theme.
Added the custom rule in the button to override the style. Before it picked the default browser, in my case `Arial`.

### Screenshots:

Before with Arial:

<img width="352" alt="Screenshot 2025-03-19 at 6 23 14 PM" src="https://github.com/user-attachments/assets/5dd6061b-861c-4b9c-befe-8434234d9e3f" />

After with Nunito Sans:
<img width="395" alt="Screenshot 2025-03-19 at 6 21 39 PM" src="https://github.com/user-attachments/assets/26a190c0-1be9-4cef-a6f5-b51b1d91f9cf" />
