### PR TITLE
Add minor rules to card header

### DIFF
--- a/src/components/molecules/Cards/BaseCard/BaseCardHeader/BaseCardHeader.tsx
+++ b/src/components/molecules/Cards/BaseCard/BaseCardHeader/BaseCardHeader.tsx
@@ -18,6 +18,7 @@ const HeaderStyled = styled(Box, {
     borderBottom: hideSeparator
       ? 'none'
       : `1px solid ${theme.palette.uiCoolGray[200]}`,
+    gap: '8px',
   })
 );
 

--- a/src/components/molecules/Cards/PrimaryCard/PrimaryCard.tsx
+++ b/src/components/molecules/Cards/PrimaryCard/PrimaryCard.tsx
@@ -44,7 +44,7 @@ export const PrimaryCard = ({
             </Typography>
           )}
         </Stack>
-        <Stack direction="row" gap={'16px'}>
+        <Stack direction="row" gap={'16px'} flexShrink={0}>
           {cardActions?.map((action, index) => (
             <Fragment key={index}>{action}</Fragment>
           ))}


### PR DESCRIPTION
## Purpose/Description:

Added couple of CSS rules to respect the size of the card actions.

### Screenshots:

Before:

![Screenshot 2025-04-08 at 11 08 16 AM](https://github.com/user-attachments/assets/105b9db7-4447-452d-b0b9-4ed8777b817b)

After: 

![Screenshot 2025-04-08 at 11 09 04 AM](https://github.com/user-attachments/assets/69c32300-eaff-455b-b341-e22f4a1278dd)
