### PR TITLE
[BRAN-1058] snackbar + modal changes

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -47,7 +47,7 @@ export type {
 } from './molecules/GraphTooltips';
 
 export { Snackbar } from './molecules/Snackbar';
-export type { SnackbarProps } from './molecules/Snackbar';
+export type { SnackbarProps, SnackbarType } from './molecules/Snackbar';
 
 export { GenericModal } from './molecules/GenericModal';
 export type { GenericModalProps } from './molecules/GenericModal';

--- a/src/components/molecules/GenericModal/GenericModal.tsx
+++ b/src/components/molecules/GenericModal/GenericModal.tsx
@@ -16,6 +16,7 @@ export interface GenericModalProps {
   children: React.ReactNode;
   open: boolean;
   onClose: () => void;
+  onExited?: () => void;
   width?: number;
 }
 
@@ -25,15 +26,20 @@ export const GenericModal = ({
   children,
   open,
   onClose,
+  onExited,
   width = 688,
 }: GenericModalProps) => {
   const { palette } = useTheme();
 
   return (
     <Dialog
+      closeAfterTransition={false}
       onClose={onClose}
       open={open}
       maxWidth="md"
+      TransitionProps={{
+        onExited: onExited,
+      }}
       PaperProps={{
         sx: {
           bgcolor: palette.uiCoolGray[50],

--- a/src/components/molecules/Snackbar/Overview.mdx
+++ b/src/components/molecules/Snackbar/Overview.mdx
@@ -7,8 +7,8 @@ import * as Stories from './Snackbar.stories';
 
 # Snackbar
 
-The `Snackbar` component provides a flexible and customizable notification interface built on top of Material UI's Snackbar and Alert components.
-It is designed to display brief messages to the user, anchored at the top-right of the screen with a maximum width of 800px.
+The `Snackbar` component provides a display component to show to the user.
+It is designed to display brief messages to the user within a maximum width of 800px.
 
 ## Usage
 
@@ -23,7 +23,6 @@ The `Snackbar` component supports several types:
 ### Key Points
 
 - **Optional Buttons:** You can include a close button, cancel button or an action button for extra options.
-- **Fixed Position:** The Snackbar always appears in the top-right corner for consistency.
 
 ## Examples
 

--- a/src/components/molecules/Snackbar/Snackbar.stories.tsx
+++ b/src/components/molecules/Snackbar/Snackbar.stories.tsx
@@ -11,7 +11,6 @@ const meta: Meta<typeof Snackbar> = {
       options: ['info', 'success', 'alert', 'warning', 'loading', 'custom'],
     },
     message: { control: 'text' },
-    open: { control: 'boolean' },
     showClose: { control: 'boolean' },
   },
 };
@@ -21,7 +20,6 @@ export default meta;
 type Story = StoryObj<typeof Snackbar>;
 
 const sharedArgs = {
-  open: true,
   showClose: true,
   onClose: () => console.log('Snackbar closed'),
   actionButton: {

--- a/src/components/molecules/Snackbar/Snackbar.tsx
+++ b/src/components/molecules/Snackbar/Snackbar.tsx
@@ -1,9 +1,9 @@
 import {
   Alert,
+  Box,
   Button,
   CircularProgress,
   IconButton,
-  Snackbar as MUISnackbar,
   Palette,
   SxProps,
   Theme,
@@ -34,8 +34,7 @@ export interface SnackbarProps {
   customIcon?: ReactNode;
   showClose?: boolean;
   actionButton?: ActionButtonProps;
-  open: boolean;
-  onClose: () => void;
+  onClose?: () => void;
 }
 
 const mapTypeToSeverity = (type: SnackbarType) => {
@@ -97,7 +96,6 @@ export function Snackbar({
   customIcon,
   showClose = false,
   actionButton,
-  open,
   onClose,
 }: SnackbarProps) {
   const { palette } = useTheme();
@@ -105,12 +103,9 @@ export function Snackbar({
   const { actionColor, icon } = setStyles(palette, type, customIcon);
 
   return (
-    <MUISnackbar
+    <Box
       id={id}
-      open={open}
-      onClose={onClose}
-      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-      sx={{ maxWidth: 800, ...customStyles?.snackbar }}
+      sx={{ display: 'flex', maxWidth: 800, ...customStyles?.snackbar }}
     >
       <Alert
         severity={severity}
@@ -158,6 +153,6 @@ export function Snackbar({
       >
         <Typography>{message}</Typography>
       </Alert>
-    </MUISnackbar>
+    </Box>
   );
 }

--- a/src/components/molecules/Snackbar/index.ts
+++ b/src/components/molecules/Snackbar/index.ts
@@ -1,2 +1,2 @@
 export { Snackbar } from './Snackbar';
-export type { SnackbarProps } from './Snackbar';
+export type { SnackbarProps, SnackbarType } from './Snackbar';


### PR DESCRIPTION
## Purpose/Description:

- Snackbar from MUI placement logic interfered with `react-toastify`, replaced it with `Box`
- Added modal changes
