### PR TITLE
BRAN-1585 - Update input hover and focus

### DIFF
--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -185,8 +185,16 @@ const themeOptions: ThemeOptions = {
     MuiOutlinedInput: {
       styleOverrides: {
         root: {
+          '& .MuiOutlinedInput-notchedOutline': {
+            borderColor: ui.coolGray[200],
+            transition: 'all 0.3s ease',
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: ui.blue[400],
+          },
           '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-            borderColor: ui.blue[500],
+            borderColor: ui.blue[400],
+            boxShadow: `0 0 4px 0 ${ui.blue[400]}`,
           },
         },
       },


### PR DESCRIPTION
## Purpose/Description:
Updated the `MuiOutlinedInput` theme overrides to align with the Figma design. Added a smooth transition for the outline, changed the border color to ui.blue[400] on hover, and applied a subtle box shadow on focus.

### Screenshots:
<img width="1133" height="175" alt="Screenshot 2025-08-21 at 11 13 17" src="https://github.com/user-attachments/assets/d9556f20-20d7-45c1-a46c-e5bb27665be7" />
<img width="403" height="116" alt="Screenshot 2025-08-21 at 11 13 38" src="https://github.com/user-attachments/assets/b69ab329-0325-4462-b0b2-f7313451c179" />
<img width="400" height="127" alt="Screenshot 2025-08-21 at 11 15 56" src="https://github.com/user-attachments/assets/dfb769d1-93f8-404c-ab02-4e4bbfac7fd6" />

## Jira Link:
[BRAN-1585
](https://collagegroup.atlassian.net/jira/software/c/projects/BRAN/boards/23?selectedIssue=BRAN-1585)
