### PR TITLE
[BRAN-1584] Updates to Snackbar and Alert components

### DIFF
--- a/src/components/molecules/Snackbar/Snackbar.tsx
+++ b/src/components/molecules/Snackbar/Snackbar.tsx
@@ -9,7 +9,7 @@ import {
   Theme,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { X as CloseIcon } from '@phosphor-icons/react';
+import { XIcon as CloseIcon } from '@phosphor-icons/react';
 import { ReactNode } from 'react';
 import { Typography } from 'src/components';
 
@@ -110,6 +110,7 @@ export function Snackbar({
       <Alert
         severity={severity}
         icon={icon}
+        variant="filled"
         sx={{
           borderColor: '10px solid blue',
           display: 'flex',
@@ -123,6 +124,18 @@ export function Snackbar({
           },
           '.MuiAlert-icon': {
             marginRight: '8px',
+          },
+          '&.MuiAlert-colorSuccess': {
+            backgroundColor: palette.uiGreen['600'],
+          },
+          '&.MuiAlert-colorInfo': {
+            backgroundColor: palette.uiCoolGray[900],
+          },
+          '&.MuiAlert-colorError': {
+            backgroundColor: palette.uiRed[600],
+          },
+          '&.MuiAlert-colorWarning': {
+            backgroundColor: palette.uiYellow[400],
           },
           color: actionColor,
           ...customStyles?.alert,

--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -21,7 +21,11 @@ import {
   ThemeOptions,
   createTheme,
 } from '@mui/material';
-import { Check, Warning, WarningOctagon } from '@phosphor-icons/react';
+import {
+  CheckIcon,
+  WarningIcon,
+  WarningOctagonIcon,
+} from '@phosphor-icons/react';
 import { audience, collage, themeColors, ui } from 'src/colors';
 import { CustomColors } from 'src/types';
 
@@ -160,24 +164,18 @@ const themeOptions: ThemeOptions = {
       defaultProps: {
         iconMapping: {
           info: <></>,
-          success: <Check size={24} color={ui.white['500']} />,
-          warning: <Warning size={24} color={ui.coolGray['900']} />,
-          error: <WarningOctagon size={24} color={ui.white['500']} />,
+          success: <CheckIcon size={24} />,
+          warning: <WarningIcon size={24} />,
+          error: <WarningOctagonIcon size={24} />,
         },
       },
       styleOverrides: {
         root: {
-          '&.MuiAlert-colorSuccess': {
-            backgroundColor: ui.green['600'],
+          '&.MuiAlert-standardWarning': {
+            border: `1px solid ${ui.yellow[500]}`,
           },
-          '&.MuiAlert-colorWarning': {
-            backgroundColor: ui.yellow['400'],
-          },
-          '&.MuiAlert-colorInfo': {
-            backgroundColor: ui.coolGray[900],
-          },
-          '&.MuiAlert-colorError': {
-            backgroundColor: ui.red[600],
+          '&.MuiAlert-standardError': {
+            border: `1px solid ${ui.red[400]}`,
           },
         },
       },


### PR DESCRIPTION
## Purpose/Description:

Updated the Alert and Snackbar components to be styled independently.
* The snackbar component was overriding the Alert component globally, affecting it's default behavior to use independently.
* Moved the color customizations over to the Snackbar component and left the Alert component with the custom colors  from the component library from Figma https://www.figma.com/design/vMprydyGvom2SXAyLxItyV/Component-Library?node-id=869-2967&p=f&m=dev.

### Screenshots:

No visual changes should appear in the Snackbar components.
<img width="358" height="157" alt="Screenshot 2025-08-31 at 8 37 38 PM" src="https://github.com/user-attachments/assets/b99f1f54-3a5b-4765-be81-323461b08c1d" />
<img width="402" height="136" alt="Screenshot 2025-08-31 at 8 37 47 PM" src="https://github.com/user-attachments/assets/5b30a15a-549f-4af1-9868-064408ddc224" />

The Alert component should change from 
<img width="635" height="167" alt="Screenshot 2025-08-31 at 8 49 49 PM" src="https://github.com/user-attachments/assets/86fe9a38-894b-436a-8d94-8732c38cb363" />
<img width="478" height="173" alt="Screenshot 2025-08-31 at 8 50 06 PM" src="https://github.com/user-attachments/assets/a7d471bb-0594-4698-b644-d1b7778f1f3f" />

To:
<img width="501" height="164" alt="Screenshot 2025-08-31 at 8 38 30 PM" src="https://github.com/user-attachments/assets/e108401e-38d8-4bb0-91bc-05373920ef06" />
<img width="660" height="185" alt="Screenshot 2025-08-31 at 8 39 41 PM" src="https://github.com/user-attachments/assets/60b60def-1bbb-42d9-b3dc-655a90c9801a" />

## Jira Link:

Link to the relevant Jira issue or task. (e.g., [PROJECT-123](https://your-jira-instance.com/browse/PROJECT-123))

