### PR TITLE
[BRAN-1739] Added prefix/suffix adornments to the graphTooltip component

### DIFF
--- a/src/components/molecules/GraphTooltips/GraphTooltips.stories.tsx
+++ b/src/components/molecules/GraphTooltips/GraphTooltips.stories.tsx
@@ -65,7 +65,7 @@ export const Default: Story = {
 export const WithUnitMeasurement: Story = {
   args: {
     ...sharedArgs,
-    unitMeasurement: '%',
+    valueAdornments: { suffix: '%' },
     rows: [
       { label: 'Population', value: '45' },
       { label: 'Growth', value: '3.2' },

--- a/src/components/molecules/GraphTooltips/GraphTooltips.tsx
+++ b/src/components/molecules/GraphTooltips/GraphTooltips.tsx
@@ -29,7 +29,7 @@ export interface TooltipParams<T> {
   arrowPosition?: ArrowPosition | undefined;
   xPosition?: xPosition;
   yPosition?: yPosition;
-  unitMeasurement?: string;
+  valueAdornments?: { prefix?: string; suffix?: string };
 }
 
 export type GraphTooltipData = {
@@ -46,7 +46,7 @@ export interface GraphTooltipPositionProps {
   top?: number;
   left?: number;
   right?: number;
-  unitMeasurement?: string;
+  valueAdornments?: { prefix?: string; suffix?: string };
   sx?: SxProps<Theme>;
 }
 
@@ -82,7 +82,7 @@ export const GraphTooltip = ({
   className,
   sx,
   rows,
-  unitMeasurement,
+  valueAdornments,
   top = 0,
   left,
   right,
@@ -127,9 +127,12 @@ export const GraphTooltip = ({
             {row.label && <Label isSingleItem={!row.value}>{row.label}</Label>}
             {row.value && (
               <Value>
+                {valueAdornments && valueAdornments.prefix && (
+                  <UnitMeasurement>{valueAdornments.prefix}</UnitMeasurement>
+                )}
                 {row.value}
-                {unitMeasurement && (
-                  <UnitMeasurement>{unitMeasurement}</UnitMeasurement>
+                {valueAdornments && valueAdornments.suffix && (
+                  <UnitMeasurement>{valueAdornments.suffix}</UnitMeasurement>
                 )}
               </Value>
             )}


### PR DESCRIPTION
## Purpose/Description:

Added the `valueAdornments` prop to the `GraphTooltip` component to add prefix/suffix adornments to the values in the tooltips.

## Jira Link:

https://collagegroup.atlassian.net/browse/BRAN-1739