### PR TITLE
Revamp mosaic colors

### DIFF
--- a/src/colors/ui.ts
+++ b/src/colors/ui.ts
@@ -71,12 +71,6 @@ const ui = {
     800: '#454c55',
     900: '#353a41',
   },
-  white: {
-    500: '#FFFFFF',
-  },
-  black: {
-    500: '#000000',
-  },
 };
 
 export default ui;

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -85,7 +85,7 @@ const ButtonRoot = styled(ButtonForwardRef)<ButtonProps>(
         padding: '12px 20px',
       }),
       ...(customVariant === 'primary' && {
-        color: theme.palette.uiWhite[500],
+        color: theme.palette.common.white,
         backgroundColor: theme.palette[mainColor][500],
         height: '40px',
         '&:hover': {
@@ -96,7 +96,7 @@ const ButtonRoot = styled(ButtonForwardRef)<ButtonProps>(
         color: theme.palette[mainColor][500],
         border: '1px solid',
         borderColor: theme.palette[mainColor][200],
-        backgroundColor: theme.palette.uiWhite[500],
+        backgroundColor: theme.palette.defaultColors.white,
         height: '40px',
         '&:hover': {
           backgroundColor: theme.palette[mainColor][50],
@@ -107,7 +107,7 @@ const ButtonRoot = styled(ButtonForwardRef)<ButtonProps>(
         color: theme.palette[mainColor][800],
         border: '1px solid',
         borderColor: theme.palette[mainColor][200],
-        backgroundColor: theme.palette.uiWhite[500],
+        backgroundColor: theme.palette.common.white,
         height: '40px',
         '&:hover': {
           backgroundColor: theme.palette.uiCoolGray[50],

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -96,7 +96,7 @@ const ButtonRoot = styled(ButtonForwardRef)<ButtonProps>(
         color: theme.palette[mainColor][500],
         border: '1px solid',
         borderColor: theme.palette[mainColor][200],
-        backgroundColor: theme.palette.defaultColors.white,
+        backgroundColor: theme.palette.common.white,
         height: '40px',
         '&:hover': {
           backgroundColor: theme.palette[mainColor][50],

--- a/src/components/molecules/Cards/BaseCard/BaseCard/BaseCard.tsx
+++ b/src/components/molecules/Cards/BaseCard/BaseCard/BaseCard.tsx
@@ -31,7 +31,7 @@ const CardStyled = styled(Box)(({ theme }) => ({
   borderRadius: '4px',
   display: 'flex',
   flexDirection: 'column',
-  backgroundColor: theme.palette.uiWhite[500],
+  backgroundColor: theme.palette.common.white,
   textAlign: 'left',
 }));
 

--- a/src/components/molecules/GraphTooltips/components/commonComponents.tsx
+++ b/src/components/molecules/GraphTooltips/components/commonComponents.tsx
@@ -43,7 +43,7 @@ export const Label = styled(
 export const Value = styled((props: TypographyProps) => (
   <Typography variant="b2" {...props} />
 ))(({ theme }) => ({
-  color: theme.palette.uiWhite[500],
+  color: theme.palette.common.white,
   minWidth: '30px',
 }));
 

--- a/src/components/molecules/Snackbar/Snackbar.tsx
+++ b/src/components/molecules/Snackbar/Snackbar.tsx
@@ -67,7 +67,7 @@ const setStyles = (
     case 'alert':
     case 'info':
     case 'loading':
-      actionColor = palette.uiWhite[500];
+      actionColor = palette.common.white;
       break;
     case 'warning':
       actionColor = palette.uiGray[800];

--- a/src/theme/augmentations.ts
+++ b/src/theme/augmentations.ts
@@ -22,7 +22,6 @@ interface CustomPalette {
   uiRed: CustomColorShades;
   uiGray: CustomColorShades;
   uiCoolGray: CustomColorShades;
-  uiWhite: CustomColorShades;
   defaultColors: DefaultColors;
 }
 
@@ -33,16 +32,16 @@ declare module '@mui/material/styles' {
   }
 
   interface CustomColorShades {
-    '50'?: string;
-    '100'?: string;
-    '200'?: string;
-    '300'?: string;
-    '400'?: string;
-    '500'?: string;
-    '600'?: string;
-    '700'?: string;
-    '800'?: string;
-    '900'?: string;
+    '50': string;
+    '100': string;
+    '200': string;
+    '300': string;
+    '400': string;
+    '500': string;
+    '600': string;
+    '700': string;
+    '800': string;
+    '900': string;
   }
 
   interface CustomPaletteOptions {
@@ -62,7 +61,6 @@ declare module '@mui/material/styles' {
     uiRed?: CustomColorShades;
     uiGray?: CustomColorShades;
     uiCoolGray?: CustomColorShades;
-    uiWhite?: CustomColorShades;
     defaultColors?: DefaultColors;
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,7 +17,6 @@ export enum PaletteColors {
   uiRed = 'uiRed',
   uiGray = 'uiGray',
   uiCoolGray = 'uiCoolGray',
-  uiWhite = 'uiWhite',
 }
 
 export enum StreamlineIcons {
@@ -44,5 +43,4 @@ export interface CustomColors {
   uiRed?: CustomColorShades;
   uiGray?: CustomColorShades;
   uiCoolGray?: CustomColorShades;
-  uiWhite?: CustomColorShades;
 }


### PR DESCRIPTION
## Purpose/Description:
Revamped the mosaic color tokens into a strongly-typed palette object.
TypeScript now fully understands the available color families and shade keys, preventing colors from being inferred as `string | undefined`.

## Jira Link:
[BRAN-1767](https://collagegroup.atlassian.net/jira/software/c/projects/BRAN/boards/23?selectedIssue=BRAN-1767)


[BRAN-1767]: https://collagegroup.atlassian.net/browse/BRAN-1767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ