### PR TITLE
[BRAN-1915] Delete wrapper around searchbox

### DIFF
--- a/src/components/atoms/SearchBox/SearchBox.tsx
+++ b/src/components/atoms/SearchBox/SearchBox.tsx
@@ -27,61 +27,55 @@ export const SearchBox = ({
   const resolvedIconColor = iconColor || palette.uiGray[400];
 
   return (
-    <Box
+    <OutlinedInput
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      fullWidth
       sx={{
-        display: 'flex',
-        padding: '4px',
-        height: '48px',
-        minHeight: '48px',
+        padding: '8px 12px',
+        height: '40px',
         backgroundColor: palette.common.white,
         ...sxSearchBox,
       }}
-    >
-      <OutlinedInput
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
-        fullWidth
-        sx={{ padding: '8px 12px' }}
-        startAdornment={
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              paddingRight: '8px',
-              height: '100%',
-              color: resolvedIconColor,
-              '.MuiOutlinedInput-root:focus-within &': {
-                color: palette.uiBlue[400],
-              },
-              ...sxIconContainer,
-            }}
-          >
-            <Icon.MagnifyingGlassIcon size={iconSize} weight="bold" />
-          </Box>
-        }
-        endAdornment={
-          value && (
-            <CustomTooltip title="Clear" arrow>
-              <Box
-                component={'span'}
-                onClick={() => onChange('')}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  flexShrink: 0,
-                  cursor: 'pointer',
-                  marginLeft: '8px',
-                  color: iconColor || hexToRgba(palette.uiGray[800], 65),
-                  '&:hover': { color: palette.uiGray[800], background: 'none' },
-                }}
-              >
-                <Icon.XCircleIcon size={iconSize} weight="bold" />
-              </Box>
-            </CustomTooltip>
-          )
-        }
-      />
-    </Box>
+      startAdornment={
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            paddingRight: '8px',
+            height: '100%',
+            color: resolvedIconColor,
+            '.MuiOutlinedInput-root:focus-within &': {
+              color: palette.uiBlue[400],
+            },
+            ...sxIconContainer,
+          }}
+        >
+          <Icon.MagnifyingGlassIcon size={iconSize} weight="bold" />
+        </Box>
+      }
+      endAdornment={
+        value && (
+          <CustomTooltip title="Clear" arrow>
+            <Box
+              component={'span'}
+              onClick={() => onChange('')}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                flexShrink: 0,
+                cursor: 'pointer',
+                marginLeft: '8px',
+                color: iconColor || hexToRgba(palette.uiGray[800], 65),
+                '&:hover': { color: palette.uiGray[800], background: 'none' },
+              }}
+            >
+              <Icon.XCircleIcon size={iconSize} weight="bold" />
+            </Box>
+          </CustomTooltip>
+        )
+      }
+    />
   );
 };


### PR DESCRIPTION
## Purpose/Description:

Removed unnecessary box outside the wrapping the searchbox and affecting its usability.

### Screenshots:

Before: Note the white box around the searchbox
<img width="1301" height="238" alt="Screenshot 2026-02-06 at 11 52 43 AM" src="https://github.com/user-attachments/assets/9663b5f6-608a-47ff-92df-87ac3816bcd0" />

After: The white box is gone, the searchbox is just its own component.
<img width="1316" height="183" alt="Screenshot 2026-02-06 at 11 53 23 AM" src="https://github.com/user-attachments/assets/8cd82646-143b-4fb5-9796-1880b3cdd458" />

## Jira Link:

https://collagegroup.atlassian.net/browse/BRAN-1915

