### PR TITLE
Adjustments to the Snackbar and GenericModal component

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -76,5 +76,5 @@ export type { RangeSliderProps } from './molecules/RangeSlider';
 export { SecondaryCard } from './molecules/Cards/SecondaryCard';
 export type { SecondaryCardProps } from './molecules/Cards/SecondaryCard';
 
-export { Snackbar } from './molecules/Snackbar';
-export type { SnackbarProps, SnackbarType } from './molecules/Snackbar';
+export { Snackbar, SnackbarType } from './molecules/Snackbar';
+export type { SnackbarProps } from './molecules/Snackbar';

--- a/src/components/molecules/GenericModal/GenericModal.stories.tsx
+++ b/src/components/molecules/GenericModal/GenericModal.stories.tsx
@@ -66,3 +66,19 @@ export const WithTagAndIcon: Story = {
   },
   ...sharedRender,
 };
+
+export const WithLeftPaneIcon: Story = {
+  args: {
+    title: {
+      text: 'Modal with Left Pane Icon',
+    },
+    leftPaneIcon: <Check size={32} />,
+    children: (
+      <Typography>
+        This modal has a tag and an end icon on the title.
+      </Typography>
+    ),
+    width: 600,
+  },
+  ...sharedRender,
+};

--- a/src/components/molecules/GenericModal/GenericModal.stories.tsx
+++ b/src/components/molecules/GenericModal/GenericModal.stories.tsx
@@ -75,7 +75,7 @@ export const WithLeftPaneIcon: Story = {
     leftPaneIcon: <Check size={32} />,
     children: (
       <Typography>
-        This modal has a tag and an end icon on the title.
+        This modal has an icon on the left pane and a title without an end icon.
       </Typography>
     ),
     width: 600,

--- a/src/components/molecules/GenericModal/GenericModal.tsx
+++ b/src/components/molecules/GenericModal/GenericModal.tsx
@@ -4,6 +4,7 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
+  Stack,
   useTheme,
 } from '@mui/material';
 import { XIcon } from '@phosphor-icons/react';
@@ -14,6 +15,7 @@ import { hexToRgba } from 'src/index';
 export interface GenericModalProps {
   tag?: string;
   title: { text: string; endIcon?: React.ReactNode };
+  leftPaneIcon?: React.ReactNode;
   children: React.ReactNode;
   open: boolean;
   onClose: () => void;
@@ -24,6 +26,7 @@ export interface GenericModalProps {
 export const GenericModal = ({
   tag,
   title,
+  leftPaneIcon,
   children,
   open,
   onClose,
@@ -49,44 +52,49 @@ export const GenericModal = ({
         },
       }}
     >
-      <DialogTitle
+      <Stack
         sx={{
-          color: palette.uiGray[800],
-          padding: '24px 32px 8px',
+          padding: leftPaneIcon ? '24px 32px 32px 24px' : '24px 32px 32px 32px',
+          flexDirection: 'row',
+          gap: '16px',
         }}
-        component="div"
       >
-        {tag && (
-          <Typography
-            variant="b3"
-            weight="semiBold"
-            sx={{ color: palette.collageRaspberry[500] }}
+        {leftPaneIcon && <Box flexShrink={0}>{leftPaneIcon}</Box>}
+        <Stack sx={{ gap: '8px', flexGrow: 1 }}>
+          <Box>
+            {tag && (
+              <Typography
+                variant="b3"
+                weight="semiBold"
+                sx={{ color: palette.collageRaspberry[500] }}
+              >
+                {tag}
+              </Typography>
+            )}
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <Typography variant="h2" weight="semiBold">
+                {title.text}
+              </Typography>
+              {title.endIcon}
+            </Box>
+          </Box>
+          <IconButton
+            aria-label="close"
+            data-testid="close"
+            onClick={onClose}
+            sx={{
+              position: 'absolute',
+              right: 8,
+              top: 8,
+              color: hexToRgba(palette.uiGray[800], 65),
+              '&:hover': { color: palette.uiGray[800], background: 'none' },
+            }}
           >
-            {tag}
-          </Typography>
-        )}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-          <Typography variant="h2" weight="semiBold">
-            {title.text}
-          </Typography>
-          {title.endIcon}
-        </Box>
-        <IconButton
-          aria-label="close"
-          data-testid="close"
-          onClick={onClose}
-          sx={{
-            position: 'absolute',
-            right: 8,
-            top: 8,
-            color: hexToRgba(palette.uiGray[800], 65),
-            '&:hover': { color: palette.uiGray[800], background: 'none' },
-          }}
-        >
-          <XIcon size={32} />
-        </IconButton>
-      </DialogTitle>
-      <DialogContent sx={{ padding: '32px' }}>{children}</DialogContent>
+            <XIcon size={32} />
+          </IconButton>
+          <Box>{children}</Box>
+        </Stack>
+      </Stack>
     </Dialog>
   );
 };

--- a/src/components/molecules/GenericModal/GenericModal.tsx
+++ b/src/components/molecules/GenericModal/GenericModal.tsx
@@ -1,12 +1,4 @@
-import {
-  Box,
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Stack,
-  useTheme,
-} from '@mui/material';
+import { Box, Dialog, IconButton, Stack, useTheme } from '@mui/material';
 import { XIcon } from '@phosphor-icons/react';
 import React from 'react';
 import { Typography } from 'src/components';

--- a/src/components/molecules/Snackbar/Snackbar.stories.tsx
+++ b/src/components/molecules/Snackbar/Snackbar.stories.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mui/material';
 import { Meta, StoryObj } from '@storybook/react';
-import { Snackbar, SnackbarProps } from 'src/components';
+import { Snackbar, SnackbarProps, SnackbarType } from 'src/components';
 
 const meta: Meta<typeof Snackbar> = {
   title: 'Molecules/Snackbar',
@@ -38,7 +38,16 @@ const sharedRender = {
 
 export const Default: Story = {
   args: {
-    type: 'info',
+    type: SnackbarType.Default,
+    message: 'This is the default snackbar',
+    ...sharedArgs,
+  },
+  ...sharedRender,
+};
+
+export const Info: Story = {
+  args: {
+    type: SnackbarType.Info,
     message: 'This is an info snackbar',
     ...sharedArgs,
   },
@@ -47,7 +56,7 @@ export const Default: Story = {
 
 export const SuccessSnackbar: Story = {
   args: {
-    type: 'success',
+    type: SnackbarType.Success,
     message: 'Operation was successful',
     ...sharedArgs,
   },
@@ -56,7 +65,7 @@ export const SuccessSnackbar: Story = {
 
 export const AlertSnackbar: Story = {
   args: {
-    type: 'alert',
+    type: SnackbarType.Alert,
     message: 'An error occurred',
     ...sharedArgs,
   },
@@ -65,7 +74,7 @@ export const AlertSnackbar: Story = {
 
 export const WarningSnackbar: Story = {
   args: {
-    type: 'warning',
+    type: SnackbarType.Warning,
     message: 'This is a warning',
     ...sharedArgs,
   },
@@ -74,7 +83,7 @@ export const WarningSnackbar: Story = {
 
 export const LoadingSnackbar: Story = {
   args: {
-    type: 'loading',
+    type: SnackbarType.Loading,
     message: 'Loading, please wait...',
     ...sharedArgs,
     showClose: false,

--- a/src/components/molecules/Snackbar/Snackbar.tsx
+++ b/src/components/molecules/Snackbar/Snackbar.tsx
@@ -24,7 +24,14 @@ export interface CustomStyles {
   button?: SxProps<Theme>;
 }
 
-export type SnackbarType = 'info' | 'success' | 'alert' | 'warning' | 'loading';
+export enum SnackbarType {
+  Default = 'default',
+  Info = 'info',
+  Success = 'success',
+  Alert = 'alert',
+  Warning = 'warning',
+  Loading = 'loading',
+}
 
 export interface SnackbarProps {
   id?: string;
@@ -39,15 +46,17 @@ export interface SnackbarProps {
 
 const mapTypeToSeverity = (type: SnackbarType) => {
   switch (type) {
-    case 'info':
+    case SnackbarType.Default:
       return 'info';
-    case 'success':
+    case SnackbarType.Info:
+      return 'info';
+    case SnackbarType.Success:
       return 'success';
-    case 'alert':
+    case SnackbarType.Alert:
       return 'error';
-    case 'warning':
+    case SnackbarType.Warning:
       return 'warning';
-    case 'loading':
+    case SnackbarType.Loading:
       return 'info';
     default:
       return 'info';
@@ -59,33 +68,26 @@ const setStyles = (
   type: SnackbarType,
   customIcon: ReactNode
 ) => {
-  let actionColor;
+  let fontColor = palette.common.white;
   let icon = null;
 
-  switch (type) {
-    case 'success':
-    case 'alert':
-    case 'info':
-    case 'loading':
-      actionColor = palette.common.white;
-      break;
-    case 'warning':
-      actionColor = palette.uiGray[800];
-      break;
-    default:
-      actionColor = palette.uiGray[800];
+  if (type === SnackbarType.Warning) {
+    fontColor = palette.uiGray[800];
   }
 
   if (customIcon) icon = customIcon;
-  if (type === 'loading')
+  if (type === SnackbarType.Loading)
     icon = (
       <CircularProgress
         size={20}
-        sx={{ color: actionColor, margin: '0px 4px 0px 8px' }}
+        sx={{ color: fontColor, margin: '0px 4px 0px 8px' }}
       />
     );
+  if (type === SnackbarType.Default && !customIcon) {
+    icon = false;
+  }
 
-  return { actionColor, icon };
+  return { fontColor, icon };
 };
 
 export function Snackbar({
@@ -100,7 +102,7 @@ export function Snackbar({
 }: SnackbarProps) {
   const { palette } = useTheme();
   const severity = mapTypeToSeverity(type);
-  const { actionColor, icon } = setStyles(palette, type, customIcon);
+  const { fontColor, icon } = setStyles(palette, type, customIcon);
 
   return (
     <Box
@@ -129,7 +131,10 @@ export function Snackbar({
             backgroundColor: palette.uiGreen['600'],
           },
           '&.MuiAlert-colorInfo': {
-            backgroundColor: palette.uiCoolGray[900],
+            backgroundColor:
+              type === SnackbarType.Info
+                ? palette.uiBlue[600]
+                : palette.uiCoolGray[900],
           },
           '&.MuiAlert-colorError': {
             backgroundColor: palette.uiRed[600],
@@ -137,7 +142,6 @@ export function Snackbar({
           '&.MuiAlert-colorWarning': {
             backgroundColor: palette.uiYellow[400],
           },
-          color: actionColor,
           ...customStyles?.alert,
         }}
         action={
@@ -145,7 +149,7 @@ export function Snackbar({
             {actionButton && (
               <Button
                 sx={{
-                  color: actionColor,
+                  color: fontColor,
                   padding: 0,
                   ...customStyles?.button,
                 }}
@@ -158,7 +162,7 @@ export function Snackbar({
             )}
             {showClose && (
               <IconButton onClick={onClose} size="small">
-                <CloseIcon weight="bold" size={16} color={actionColor} />
+                <CloseIcon weight="bold" size={16} color={fontColor} />
               </IconButton>
             )}
           </>

--- a/src/components/molecules/Snackbar/index.ts
+++ b/src/components/molecules/Snackbar/index.ts
@@ -1,2 +1,2 @@
-export { Snackbar } from './Snackbar';
-export type { SnackbarProps, SnackbarType } from './Snackbar';
+export { Snackbar, SnackbarType } from './Snackbar';
+export type { SnackbarProps } from './Snackbar';

--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -23,6 +23,7 @@ import {
 } from '@mui/material';
 import {
   CheckIcon,
+  InfoIcon,
   WarningIcon,
   WarningOctagonIcon,
 } from '@phosphor-icons/react';
@@ -166,7 +167,7 @@ const themeOptions: ThemeOptions = {
     MuiAlert: {
       defaultProps: {
         iconMapping: {
-          info: <></>,
+          info: <InfoIcon size={24} />,
           success: <CheckIcon size={24} />,
           warning: <WarningIcon size={24} />,
           error: <WarningOctagonIcon size={24} />,


### PR DESCRIPTION
## Purpose/Description:

Modified the Snackbar component to add the missing blue info snackbar
Modified the GenericModal component to fit an optional icon to its left hand side.

### Screenshots:

Snackbar:
<img width="687" height="614" alt="Screenshot 2026-02-16 at 7 53 42 PM" src="https://github.com/user-attachments/assets/9a65de44-1c5d-4d7f-b1df-0e048bfede10" />

GenericModal:

<img width="1022" height="476" alt="Screenshot 2026-02-17 at 4 59 13 PM" src="https://github.com/user-attachments/assets/b42f7b20-33fe-47ef-aff3-e0721ea5ae18" />

## Jira Link:

https://collagegroup.atlassian.net/browse/BRAN-1925

